### PR TITLE
Fix header parsing for 64-bit CPUs

### DIFF
--- a/src/pxparse.c
+++ b/src/pxparse.c
@@ -165,7 +165,7 @@ px_fieldInfo **PXparseCompleteHeader (int fd, px_header *header) {
 	char unp_head[0x58];
 	char unp_head4[0x20];
 	unsigned char d[2];
-	void *ptr;
+	char ptr[4];
 	
 	int i;
 	char c;


### PR DESCRIPTION
I had trouble parsing some table headers (the fields would come out garbled or empty), and after finding a note from the original author that a 32-build should be used and confirming that helps I traced it to this single variable that is used for it's "sizeof" to advance the file pointer.

Making sure it's always 4 bytes helped. The actual value isn't used, as far as I can tell, but I didn't want to change more than needed.