### PR TITLE
Various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ Makefile.in
 
 pxtools.spec
 
+po/POTFILES
+
 src/pxcsvdump
 src/pxinfo
 src/pxsqldump

--- a/src/pxconvert.c
+++ b/src/pxconvert.c
@@ -364,15 +364,15 @@ char *PXMEMOtoString(void *blob, int size, char *blobname) {
 	copy_from_le(&offset, (char *)blob+(size-10), 4);
 	copy_from_le(&length, (char *)blob+(size-6), 4);
 	copy_from_le(&mod_number, (char *)blob+(size-2), 2);
-	
+
 	copy_from_le(&index, (char *)blob+(size-10), 1);
-	
+
 	offset &= 0xffffff00;
-#ifdef DEBUG	
+#ifdef DEBUG
 	fprintf(stderr, "[BLOB] offset: %08lx, length: %08lx, mod_number: %04x, index: %02x\n", offset, length, mod_number, index);
 #endif
-	if (index == 0x00) return NULL;
-	
+	if (offset == 0) return NULL;
+
 	if (!blobname) {
 		fprintf(stderr, "[BLOB] offset: %08lx, length: %08lx, mod_number: %04x, index: %02x - do I need a BLOB-filename '-b ...' ?\n", offset, length, mod_number, index);
 		return NULL;
@@ -383,7 +383,7 @@ char *PXMEMOtoString(void *blob, int size, char *blobname) {
 	fd = open(blobname, O_RDONLY);
 #endif
 	if (fd == -1) return NULL;
-	
+
 	if (index == 0xff) {
 		/* type 02 block */
 		mb_type2_pointer idx;
@@ -480,14 +480,14 @@ int PXBLOBtoBinary(void *blob, int size, char *blobname, void ** binstorage, int
 	copy_from_le(&offset, (char *)blob+(size-10), 4);
 	copy_from_le(&length, (char *)blob+(size-6), 4);
 	copy_from_le(&mod_number, (char *)blob+(size-2), 2);
-	
+
 	copy_from_le(&index, (char *)blob+(size-10), 1);
-	
+
 	offset &= 0xffffff00;
-#ifdef DEBUG	
+#ifdef DEBUG
 	fprintf(stderr, "[BLOB] offset: %08lx, length: %08lx, mod_number: %04x, index: %02x\n", offset, length, mod_number, index);
 #endif
-	if (index == 0x00) return 0;
+	if (offset == 0) return 0;
 	
 	if (!blobname) {
 		fprintf(stderr, "[BLOB] offset: %08lx, length: %08lx, mod_number: %04x, index: %02x - do I need a BLOB-filename '-b ...' ?\n", offset, length, mod_number, index);

--- a/src/pxconvert.c
+++ b/src/pxconvert.c
@@ -325,17 +325,7 @@ int PXtoQuotedString(char *dst, const unsigned char *src, int type) {
 	}
 	
 	while(*src) {
-		switch(*src) {
-/* cp431(??) -> latin1 */
-			case 0x81: *dst = 'ü'; break;
-			case 0x84: *dst = 'ä'; break;
-			case 0x8e: *dst = 'Ä'; break;
-			case 0x94: *dst = 'ö'; break;
-			case 0x99: *dst = 'Ö'; break;
-			case 0x9a: *dst = 'Ü'; break;
-			case 0xe1: *dst = 'ß'; break;
-			default: *dst = *src;
-		}
+		*dst = *src;
 		dst++;
 		src++;
 	}
@@ -344,21 +334,6 @@ int PXtoQuotedString(char *dst, const unsigned char *src, int type) {
 }
 
 char *PXNametoQuotedName(char *str) {
-	unsigned char *s = str;
-	while(*s) {
-		switch(*s) {
-			case 0x81: *s = 'ü'; break;
-			case 0x84: *s = 'ä'; break;
-			case 0x8e: *s = 'Ä'; break;
-			case 0x94: *s = 'ö'; break;
-			case 0x99: *s = 'Ö'; break;
-			case 0x9a: *s = 'Ü'; break;
-			case 0xe1: *s = 'ß'; break;
-			case 0x20: *s = '_'; break;
-			case '-' : *s = '_'; break;
-		}
-		s++;
-	}
 	return str;
 }
 

--- a/src/pxparse.c
+++ b/src/pxparse.c
@@ -165,7 +165,7 @@ px_fieldInfo **PXparseCompleteHeader (int fd, px_header *header) {
 	char unp_head[0x58];
 	char unp_head4[0x20];
 	unsigned char d[2];
-	void *ptr;
+	char ptr[4];
 	
 	int i;
 	char c;

--- a/src/pxsqldump.c
+++ b/src/pxsqldump.c
@@ -447,7 +447,8 @@ char * str_to_sql(const unsigned char *src)
 	
 char * binary_to_sql(const unsigned char *src, int src_len, int *dst_len)
 {
-	unsigned int i, add;
+	int i;
+	unsigned int j, add;
 	char * dst = NULL;
 
   /* count the numbers of ' */
@@ -457,14 +458,14 @@ char * binary_to_sql(const unsigned char *src, int src_len, int *dst_len)
 		    src[i] == '\\') add++;
 	}
 
-	dst = malloc((i + add) * sizeof(char));
-	*dst_len = i + add;
+	dst = malloc((src_len + add) * sizeof(char));
+	*dst_len = src_len + add;
 
-	for (i = 0; i < src_len; src++)
+	for (i = 0, j = 0; i < src_len; i++)
 	{
 		unsigned int c = 0;
 
-		if (*src == '\'')
+		if (src[i] == '\'')
 		{
 			switch (dbtype)
 			{
@@ -472,7 +473,7 @@ char * binary_to_sql(const unsigned char *src, int src_len, int *dst_len)
 			    case DB_MYSQL: c = '\\'; break;
 			}
 		}
-		if (*src == '\\')
+		if (src[i] == '\\')
 		{
 			switch (dbtype)
 			{
@@ -482,9 +483,9 @@ char * binary_to_sql(const unsigned char *src, int src_len, int *dst_len)
 		}
 
 		if (c)
-			dst[i++] = c;
+			dst[j++] = c;
 
-		dst[i++] = *src;
+		dst[j++] = src[i];
 	}
 
 	return dst;

--- a/src/pxxmldump.c
+++ b/src/pxxmldump.c
@@ -25,7 +25,7 @@ const char *tags [] = {
   "logical",
   "timestamp",
   "incremental",
-  "bcd"
+  "bcd",
   "time",
 };
 

--- a/src/pxxmldump.c
+++ b/src/pxxmldump.c
@@ -77,13 +77,11 @@ int create_xml_line(px_header *header, px_fieldInfo **felder, px_records block, 
 			free(str);
     } else if (felder[i]->type == PX_Field_Type_BCD) {
       char *str = malloc(felder[i]->size + 1);
-			
-      fprintf(stderr,"aslhföasdhfsadbf\n"),
-			
-	BLOCK_COPY(str, felder[i]->size);
-			
+
+      BLOCK_COPY(str, felder[i]->size);
+
       printf("%s", str);
-			
+
       free(str);
     } else if (felder[i]->type == PX_Field_Type_ShortInt) {
       unsigned short s;


### PR DESCRIPTION
I do not expect this PR to be merged, but I am making it for visibility. We had to use this tool to convert some old Paradox data to a new format and found this tool good, but not perfect and had to fix it in few places to convert it without data loss.

* Support on 64 bit systems.
* It does not try to specially handle encoded characters, but leaves this to the user to post-process. We had some tables in one 8-bit code table and some tables in another. Which code table is used is obtainable from Paradox metadata (using pxinfo tool from this repository) and then we just post-process it in Python and convert to unicode. Easier than putting this into pxtools.
* There was a bug which prevented some blobs from being correctly read. Only first 10 bytes were. Fixed.